### PR TITLE
refactor: replace all `NuxtLink` with `ULink` component

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -77,28 +77,28 @@ const columns: FooterColumn[] = [
     <template #default>
       <p class="text-muted text-sm">
         Created with template
-        <NuxtLink
+        <ULink
           aria-label="quick-conf GitHub Repository"
           class="text-primary/70"
           target="_blank"
           to="https://github.com/toddeTV/quick-conf"
         >
           quick-conf
-        </NuxtLink>
+        </ULink>
         <!-- @ -->
         <UIcon
           aria-hidden="true"
           class="inline-block w-3.5 h-3.5 mx-0.5"
           name="i-lucide-heart"
         />
-        <NuxtLink
+        <ULink
           aria-label="Website of Thorsten Seyschab"
           class="text-primary/70"
           target="_blank"
           to="https://todde.tv/"
         >
           Thorsten Seyschab
-        </NuxtLink>
+        </ULink>
       </p>
     </template>
 

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -28,13 +28,13 @@ const items = computed(() => [
 <template>
   <UHeader mode="slideover">
     <template #left>
-      <NuxtLink
+      <ULink
         aria-label="Home"
         class="mr-0 md:mr-8"
         to="/"
       >
         <AppLogo class="w-auto h-6 shrink-0" />
-      </NuxtLink>
+      </ULink>
 
       <UNavigationMenu
         class="hidden lg:inline-flex"

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -54,12 +54,12 @@ useSeoMeta({
       <UPageHeader :description="description" :title="title" />
 
       <div v-for="talk in processedData" :key="talk.slug">
-        <NuxtLink
+        <ULink
           :aria-label="`View details for ${talk.title} at ${talk.dateTime}`"
           :to="`/talks/${talk.slug}`"
         >
           {{ talk.title }} at {{ talk.dateTime }}
-        </NuxtLink>
+        </ULink>
       </div>
     </UContainer>
   </template>

--- a/app/pages/speakers/[...slug].vue
+++ b/app/pages/speakers/[...slug].vue
@@ -45,12 +45,12 @@ useSeoMeta({
       <div>
         Given Talks/Workshops:<br>
         <div v-for="talk in talks" :key="talk.slug">
-          <NuxtLink
+          <ULink
             :aria-label="`View details for Talk '${talk.title}'`"
             :to="`/talks/${talk.slug}`"
           >
             {{ talk.title }}
-          </NuxtLink>
+          </ULink>
         </div>
       </div>
     </UContainer>

--- a/app/pages/speakers/index.vue
+++ b/app/pages/speakers/index.vue
@@ -20,12 +20,12 @@ useSeoMeta({
       <UPageHeader :description="description" :title="title" />
 
       <div v-for="speaker in speakers" :key="speaker.slug">
-        <NuxtLink
+        <ULink
           :aria-label="`View details for Speaker '${speaker.name}'`"
           :to="`/speakers/${speaker.slug}`"
         >
           {{ speaker.name }}
-        </NuxtLink>
+        </ULink>
       </div>
     </UContainer>
   </template>

--- a/app/pages/talks/[...slug].vue
+++ b/app/pages/talks/[...slug].vue
@@ -55,7 +55,7 @@ useSeoMeta({
       <div>
         Speakers:<br>
         <div v-for="speaker in speakers" :key="speaker.slug">
-          <NuxtLink
+          <ULink
             :aria-label="`View details for Speaker ${speaker.name}`"
             :to="`/speakers/${speaker.slug}`"
           >
@@ -66,7 +66,7 @@ useSeoMeta({
               class="w-16 h-16 object-cover"
               :src="speaker.image"
             />
-          </NuxtLink>
+          </ULink>
         </div>
       </div>
 


### PR DESCRIPTION
This PR refactors the application's link components. It replaces all instances of `NuxtLink` with `ULink` to leverage the `NuxtUI` component library for consistent styling and behavior.

**Specifically, it addresses and includes the following:**

- All `NuxtLink` components have been replaced with `ULink`.
- The refactoring ensures consistent link styling and functionality.
- No regressions in navigation or component behavior were observed during testing.
- Codebase now uses a single, standardized link component.

**Follow-up Tasks & Future Improvements**

- #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated link component implementations across navigation elements (headers, footers, and page links).
  * All navigation functionality and user experience remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->