### PR TITLE
chore: bump version to 1.2.0-rc.0 after release

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Documentation
 
 > [!IMPORTANT]
-> This documentation applies to **quick-conf v1.1.0**. <!-- x-release-please-version -->
+> This documentation applies to **quick-conf v1.2.0-rc.0**. <!-- x-release-please-version -->
 
 > [!TIP]
 > **Looking for the documentation for your version?** You can always find the documentation matching your installed version by clicking the **version number** in the footer of your own website instance.<br>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quick-conf",
   "isQuickConfTemplate": true,
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.2.0-rc.0",
   "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677",
   "description": "This is a template for quickly setting up a new Conference or Meetup website with various functionalities.",
   "author": "Thorsten Seyschab <business@todde.tv> (https://todde.tv/)",


### PR DESCRIPTION
Automated version bump to next RC version after the last release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.2.0-rc.0 (release candidate)

* **Documentation**
  * README updated to reflect the new target version (1.2.0-rc.0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->