### PR TITLE
chore: align CI/tooling with Node 24 & standardize scripts

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -14,12 +14,12 @@ reviews:
 
   # Edit the PR description with a generated summary.
   high_level_summary: true
-  high_level_summary_placeholder: "@coderabbitai summary"
+  high_level_summary_placeholder: '@coderabbitai summary'
   # high_level_summary_instructions:
   # high_level_summary_in_walkthrough: false
 
   # Generate the PR title if this is the title.
-  auto_title_placeholder: "@coderabbitai"
+  auto_title_placeholder: '@coderabbitai'
   # auto_title_instructions:
 
   # Print info about the review.

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -158,8 +158,8 @@ reviews:
     # More ways to filter when to run automatic reviews.
     # ignore_title_keywords:
     #   -
-    # labels:
-    #   - "!autorelease: pending" # Exclude release-please bot PRs that are waiting for release.
+    labels:
+      - '!autorelease: pending' # Exclude release-please bot PRs that are waiting for release.
     # base_branches:
     #   -
     # ignore_usernames:

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -178,11 +178,18 @@ reviews:
 # Configure knowledge base features to let the AI learn from your project's documentation and past reviews.
 knowledge_base:
   learnings:
-    # "auto" allows the AI to automatically learn from PR feedback and apply it to future reviews.
-    scope: auto
+    # Scope for storing/reusing learned feedback from PR reviews.
+    # Possible values:
+    # - "local": learnings are scoped to this repository only.
+    # - "global": learnings are shared across the organization/workspace.
+    # - "auto": uses local for public repos, global for private repos.
+    scope: local
 
   code_guidelines:
-    # Enable the AI to read and apply project-specific documentation.
+    # Whether CodeRabbit should apply coding-guideline documents during review.
+    # Possible values:
+    # - true: enable reading and applying guideline files.
+    # - false: disable guideline-based review behavior.
     enabled: true
 
     # Index documentation to understand project conventions.

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -82,7 +82,8 @@ reviews:
     - '!node_modules/**'
 
   # Special instructions for certain code paths.
-  # CRITICAL: Since no AI rules are in the project, these rules completely define the project standards.
+  # CRITICAL: `path_instructions` play a primary role in defining project standards alongside documentation-based
+  #           guidance when `knowledge_base.code_guidelines.enabled` is true.
   path_instructions:
     - path: '**/*.{ts,js,vue,mjs}'
       instructions: |

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,7 +6,7 @@ enable_free_tier: false
 
 reviews:
   # "assertive" emits a broad range of issues including nitpicks and improvements.
-  # "chill" only reports critical issues.
+  # "chill" provides lighter feedback with fewer non-critical comments.
   profile: assertive
 
   # If true, CodeRabbit will request changes on the PR if there are issues. If false, it will only comment.
@@ -14,12 +14,12 @@ reviews:
 
   # Edit the PR description with a generated summary.
   high_level_summary: true
-  high_level_summary_placeholder: '@coderabbitai summary'
+  high_level_summary_placeholder: "@coderabbitai summary"
   # high_level_summary_instructions:
   # high_level_summary_in_walkthrough: false
 
   # Generate the PR title if this is the title.
-  auto_title_placeholder: '@coderabbitai'
+  auto_title_placeholder: "@coderabbitai"
   # auto_title_instructions:
 
   # Print info about the review.
@@ -64,14 +64,14 @@ reviews:
   suggested_reviewers: false
   # auto_assign_reviewers: false
 
-  # Disable "fun" content like fortunes and poems to maintain professional tone.
+  # Disable "fun" content like fortunes and poems in the review summary.
   in_progress_fortune: false
   poem: false
 
-  # Include a "Prompt for AI Agents" section in review comments.
+  # Include a "Prompt for AI Agents" section in review comments with instructions for other AI tools to implement the suggestion.
   enable_prompt_for_ai_agents: true
 
-  # Only run on relevant paths.
+  # Only run on these paths. Omit to run on all.
   path_filters:
     - '!pnpm-lock.yaml'
     - '!**/*.min.js'
@@ -82,7 +82,7 @@ reviews:
     - '!node_modules/**'
 
   # Special instructions for certain code paths.
-  # CRITICAL: Since .github/instructions are not in the repo, these rules completely define the project standards.
+  # CRITICAL: Since no AI rules are in the project, these rules completely define the project standards.
   path_instructions:
     - path: '**/*.{ts,js,vue,mjs}'
       instructions: |
@@ -148,11 +148,22 @@ reviews:
   auto_review:
     # We want automatic reviews.
     enabled: true
+
+    # And also incremental ones.
     auto_incremental_review: true
-    # Only run review on PRs with the following labels (or exclude by negative matching)
-    labels:
-      - '!autorelease: pending' # Exclude release-please bot PRs that are waiting for release.
-    drafts: false
+
+    # Review draft PRs.
+    drafts: true
+
+    # More ways to filter when to run automatic reviews.
+    # ignore_title_keywords:
+    #   -
+    # labels:
+    #   - "!autorelease: pending" # Exclude release-please bot PRs that are waiting for release.
+    # base_branches:
+    #   -
+    # ignore_usernames:
+    #   -
 
   finishing_touches:
     # Disable AI generation of docstrings/tests as we prefer manual control or existing suites.
@@ -164,7 +175,7 @@ reviews:
   # Do not download the repo for each review.
   disable_cache: false
 
-# Configure knowledge base features to let the AI learn from your project's documentation.
+# Configure knowledge base features to let the AI learn from your project's documentation and past reviews.
 knowledge_base:
   learnings:
     # "auto" allows the AI to automatically learn from PR feedback and apply it to future reviews.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       # Bump to next RC version

--- a/.github/workflows/validation-and-tests.yml
+++ b/.github/workflows/validation-and-tests.yml
@@ -33,11 +33,11 @@ jobs:
       matrix:
         include:
           - name: Lint & Format Check
-            command: pnpm test:lint
+            command: pnpm run test:lint-format
           - name: Type Check
-            command: pnpm test:types
+            command: pnpm run test:types
           - name: Renovate Config Check
-            command: pnpm test:renovate
+            command: pnpm run test:renovate
 
     steps:
       # Check out the repository
@@ -81,7 +81,7 @@ jobs:
           # The flexible approach: a job is also considered "passed" if it was intentionally skipped.
           # This is important for conditional jobs that should only run if specific files have changed
           # (e.g., using an `if:` condition). In such cases, 'skipped' is a valid, non-error state.
-          # echo '<DOLLAR_SYMBOL>{{ toJSON(needs) }}' | jq -e 'all(.result == "success" or .result == "skipped")'
+          echo '${{ toJSON(needs) }}' | jq -e 'all(.result == "success" or .result == "skipped")'
 
-          # The strict approach: only 'success' is accepted. This will fail if any job is skipped.
-          echo '${{ toJSON(needs) }}' | jq -e 'all(.result == "success")'
+          # # The strict approach: only 'success' is accepted. This will fail if any job is skipped.
+          # echo '<DOLLAR_SYMBOL>{{ toJSON(needs) }}' | jq -e 'all(.result == "success")'

--- a/.github/workflows/validation-and-tests.yml
+++ b/.github/workflows/validation-and-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       # Install project dependencies using the custom script.

--- a/.gitignore
+++ b/.gitignore
@@ -23,17 +23,9 @@ logs
 .env.*
 !.env.example
 
-# only specific files in `.vscode`
-.vscode/*
-!.vscode/settings.json
-!.vscode/extensions.json
+# no AI files (AI should only be used for reviewing code, not for generating it)
+CLAUDE.md
+.claude
 
-# only specific files in `.github`
-.github/*
-!.github/actions/
-!.github/workflows/
-!.github/dependabot.yml
-!.github/FUNDING.yml
-
-# Ignore `*.psd` files in `/docs/assets`
-/docs/assets/**/*.psd
+# Skilld references (recreated by `skilld install`)
+.skilld

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,6 @@
   "[vue]": {
     "editor.defaultFormatter": "Vue.volar"
   },
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
-    "source.organizeImports": "never"
-  },
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "editor.formatOnSave": false,
   "editor.linkedEditing": true,
   "editor.quickSuggestions": {
     "strings": "on"
@@ -58,6 +52,14 @@
     "postcss"
   ],
   "prettier.enable": false,
+  "eslint.enable": true,
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
+  },
+
+  "editor.formatOnSave": false,
 
   // search
   "search.exclude": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "isQuickConfTemplate": true,
   "type": "module",
   "version": "1.2.0-rc.0",
-  "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677",
+  "packageManager": "pnpm@10.33.0",
   "description": "This is a template for quickly setting up a new Conference or Meetup website with various functionalities.",
   "author": "Thorsten Seyschab <business@todde.tv> (https://todde.tv/)",
   "contributors": [
@@ -37,7 +37,7 @@
     "website"
   ],
   "engines": {
-    "node": "22.x",
+    "node": "24.x",
     "pnpm": "10.x"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 nuxt build",
     "dev": "nuxt dev",
     "dev:preset": "nuxt dev --port 3000 --public",
-    "fix:lint": "run-s \"test:lint --fix\"",
+    "fix": "run-s fix:*",
+    "fix:lint-format": "run-s \"test:lint-format --fix\"",
     "generate": "cross-env NODE_OPTIONS=--max-old-space-size=8192 nuxt generate",
     "nuxi": "nuxi",
     "nuxt": "nuxt",
@@ -52,7 +53,7 @@
     "preview": "nuxt preview",
     "reset": "rimraf node_modules .nuxt .output dist .data",
     "test": "run-s test:*",
-    "test:lint": "eslint .",
+    "test:lint-format": "eslint .",
     "test:renovate": "renovate-config-validator",
     "test:types": "nuxt typecheck"
   },


### PR DESCRIPTION
This PR upgrades the CI/runtime toolchain to Node 24 and pnpm 10.33.0, aligns workflow validation commands with updated package scripts, and cleans repository-level automation/configuration files for consistency.

**Specifically, it addresses and includes the following:**

- Updated GitHub Actions workflows to run on Node 24 and kept package manager metadata aligned to pnpm 10.33.0 in `package.json`.
- Renamed and standardized script entrypoints from `test:lint`/`fix:lint` to `test:lint-format`/`fix:lint-format`, and updated CI matrix commands to invoke them consistently.
- Adjusted the validation workflow `needs` status gate to use the flexible `success`/`skipped` check as the active command and retained the strict variant as commented guidance.
- Refactored `.gitignore` to explicitly exclude AI while removing previous whitelist patterns for `.vscode` and `.github` contents.
- Reordered and normalized `.vscode/settings.json` formatter/eslint settings and clarified `.coderabbit.yml` comments and auto-review behavior (including enabling draft reviews and documenting optional label/branch/user filters).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Node.js requirement bumped to 24.x and pnpm upgraded to 10.33.0; package scripts renamed/added (lint → lint-format, new fix tasks).
  * Auto-review behavior updated: incremental auto-reviews enabled, drafts included, and review guidance/comments expanded.
  * Ignore rules expanded for AI/regenerated files and editor settings adjusted to explicitly enable ESLint.

* **CI**
  * CI workflows updated to use Node 24 and test matrix/lint commands refactored; final checks aggregation made more flexible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->