### PR TITLE
docs: update usage guide with PRINTED Europe showcase entry

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,9 @@ I appreciate you being a part of this community!
 
 ## Event Showcase
 
-The following conferences and meetups are powered by this template:
+The following conferences and meetups are powered by this quick-conf template:
 
-- _Currently, no events are listed. Be the first to add yours!_
+- **PRINTED Europe**<br>
+  A conference for 3D printing, additive manufacturing, and the maker community.
+  - [printed-europe.com](https://printed-europe.com)
+  - [Repository](https://github.com/PRINTED-events/printed-europe.com)


### PR DESCRIPTION
This PR updates the usage documentation by replacing the empty event showcase placeholder with a concrete, real-world example.

**Specifically, it addresses and includes the following:**

- Rewrites the event showcase intro line to explicitly reference the quick-conf template.
- Replaces the `_Currently, no events are listed..._` placeholder with a showcase block for **PRINTED Europe** conference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified template naming in usage guide
  * Added example event entry with description and resource links for reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->