### PR TITLE
chore: switch `@nuxt/content` to native sqlite connector

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -91,6 +91,14 @@ export default defineNuxtConfig({
 
   content: { // for `@nuxt/content`
     experimental: {
+      // Connector selection order in @nuxt/content v3.11.2 (findBestSqliteAdapter):
+      // 1) bun runtime -> bun-sqlite
+      // 2) sqliteConnector: 'native' + node:sqlite available -> node-sqlite
+      // 3) sqliteConnector: 'sqlite3' -> sqlite3
+      // 4) sqliteConnector: 'better-sqlite3' -> better-sqlite3
+      // 5) webcontainer -> sqlite3
+      // 6) fallback -> better-sqlite3
+      // -> Native sqlite is available from Node.js >= 22.5.0, so that is what we use now.
       sqliteConnector: 'native',
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -90,6 +90,9 @@ export default defineNuxtConfig({
   },
 
   content: { // for `@nuxt/content`
+    experimental: {
+      sqliteConnector: 'native',
+    },
   },
 
   studio: { // for `nuxt-studio`

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@types/luxon": "~3.7.1",
     "@types/youtube": "~0.1.2",
     "@unhead/vue": "~2.0.19",
-    "better-sqlite3": "~12.6.2",
     "cross-env": "~10.1.0",
     "eslint": "~9.39.4",
     "eslint-plugin-format": "~1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       '@unhead/vue':
         specifier: ~2.0.19
         version: 2.0.19(vue@3.5.32(typescript@5.9.3))
-      better-sqlite3:
-        specifier: ~12.6.2
-        version: 12.6.2
       cross-env:
         specifier: ~10.1.0
         version: 10.1.0
@@ -14220,6 +14217,7 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   bignumber.js@9.3.1: {}
 
@@ -14236,6 +14234,7 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   boolbase@1.0.0: {}
 
@@ -14284,6 +14283,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   buffer@6.0.3:
     dependencies:
@@ -14428,7 +14428,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   chownr@2.0.0: {}
 
@@ -14700,7 +14701,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deep-extend@0.6.0: {}
+  deep-extend@0.6.0:
+    optional: true
 
   deep-is@0.1.4: {}
 
@@ -15420,7 +15422,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   exponential-backoff@3.1.3:
     optional: true
@@ -15647,7 +15650,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fs-extra@11.3.0:
     dependencies:
@@ -15776,7 +15780,8 @@ snapshots:
     dependencies:
       git-up: 8.1.1
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   github-slugger@2.0.0: {}
 
@@ -16206,7 +16211,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8: {}
+  ini@1.3.8:
+    optional: true
 
   ini@4.1.1: {}
 
@@ -17242,7 +17248,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mkdirp@0.5.6:
     dependencies:
@@ -17305,7 +17312,8 @@ snapshots:
 
   nanotar@0.2.1: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   napi-postinstall@0.3.4: {}
 
@@ -17430,6 +17438,7 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+    optional: true
 
   node-addon-api@7.1.1: {}
 
@@ -18418,6 +18427,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -18615,6 +18625,7 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    optional: true
 
   re2@1.23.0:
     dependencies:
@@ -19538,7 +19549,8 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
-  strip-json-comments@2.0.1: {}
+  strip-json-comments@2.0.1:
+    optional: true
 
   strip-json-comments@3.1.1: {}
 
@@ -19604,6 +19616,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -19612,6 +19625,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   tar-stream@3.1.8:
     dependencies:
@@ -19746,6 +19760,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   tunnel@0.0.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,6 @@ patchedDependencies:
   nuxt-studio@1.6.0: patches/nuxt-studio.patch
 allowBuilds:
   '@parcel/watcher': true
-  better-sqlite3: true
   core-js-pure: false
   dtrace-provider: false
   esbuild: true

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm run vercel:build",
   "env": {
-    "NITRO_PRESET": "vercel",
-    "NPM_CONFIG_BUILD_FROM_SOURCE": "true"
+    "NITRO_PRESET": "vercel"
   },
   "framework": "nuxtjs",
   "installCommand": "pnpm run vercel:install",


### PR DESCRIPTION
This PR migrates `@nuxt/content` SQLite usage to Node native sqlite, removes `better-sqlite3` from project dependencies.

**Specifically, it addresses and includes the following:**

- Sets `content.experimental.sqliteConnector` to `native` in Nuxt config.
- Removes `better-sqlite3` from `devDependencies` and `pnpm-workspace.yaml` allowBuilds.
- Removes `NPM_CONFIG_BUILD_FROM_SOURCE` from `vercel.json` env for deploy builds.
- Documents `@nuxt/content` adapter resolution order and Node native sqlite availability in config comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized SQLite database connector configuration for native execution
  * Streamlined build dependencies and deployment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->