### PR TITLE
feat: switch Nuxt Icon to client scan bundle mode & drop noto icon pack

### DIFF
--- a/app/schemas/customConfig.ts
+++ b/app/schemas/customConfig.ts
@@ -9,6 +9,13 @@ export const customConfigSchema = z.object({
       + 'You must restart the development server or rebuild the application to see your changes.',
   }),
 
+  _warningIcons: property(z.object({}).readonly()).editor({
+    // @ts-expect-error `description` is custom and patched in `nuxt-studio`
+    description: '⚠️ ICON NOTE: New icon names that are not used anywhere in project files yet can be missing '
+      + 'in Nuxt Studio live preview until the next rebuild and redeploy. A missing preview icon does not '
+      + 'mean the icon will fail after deployment.',
+  }),
+
   general: property(z.object({
     conferenceName: property(z.string().min(1)).editor({
       // @ts-expect-error `description` is custom and patched in `nuxt-studio`

--- a/docs/icon-usage.md
+++ b/docs/icon-usage.md
@@ -11,3 +11,10 @@ _Tip_: Favorite them and use the search over all item collections at once: https
 | `Lucide`                | `lucide`       | ISC License (commercial use allowed, no attribution required) |                  |
 | `Material Design Icons` | `mdi`          | Apache 2.0 (commercial use allowed, no attribution required)  |                  |
 | `Simple Icons`          | `simple-icons` | CC0 1.0 (public domain, no attribution required)              | Brand logos only |
+
+## Icons Set in Nuxt Studio CMS
+
+Icon names are collected at build time from project files in `app/`, `shared/`, and `content/` (for example `.json`, `.md`, `.yml`). If you change an icon name in Nuxt Studio, the new icon appears after the next build. For detection to work, the icon name must exist as a literal string in one of those scanned files. Literal strings in helpers or constants are detected too when those files are inside the scanned folders.
+
+> [!WARNING]
+> If you choose a new icon that is not used anywhere in the project yet, Nuxt Studio live preview can show no icon until the next rebuild and redeploy. A missing icon in preview during editing does not mean the icon name is invalid.

--- a/docs/icon-usage.md
+++ b/docs/icon-usage.md
@@ -11,4 +11,3 @@ _Tip_: Favorite them and use the search over all item collections at once: https
 | `Lucide`                | `lucide`       | ISC License (commercial use allowed, no attribution required) |                  |
 | `Material Design Icons` | `mdi`          | Apache 2.0 (commercial use allowed, no attribution required)  |                  |
 | `Simple Icons`          | `simple-icons` | CC0 1.0 (public domain, no attribution required)              | Brand logos only |
-| `Noto Emojis`           | `noto`         | Apache 2.0 (commercial use allowed, no attribution required)  | Classic Emojis   |

--- a/docs/template-usage.md
+++ b/docs/template-usage.md
@@ -192,7 +192,7 @@ For easily managing the template, we provide a CLI tool to streamline the proces
 > [!NOTE]
 > Changes made in the CMS are only visible to you until saved in the sidebar. Save your updates to make them public. After saving, it takes about 2–10 minutes for changes to go live while the website rebuilds. Avoid saving too frequently; each save triggers a new build, and you may be charged per build depending on your hosting provider.
 >
-> Icon names are collected at build time from project files in `app/`, `shared/`, and `content/` (for example `.json`, `.md`, `.yml`). If you change an icon name in Nuxt Studio, the new icon appears after the next build. Literal icon names are required for detection.
+> Some icons can stay invisible in live preview until the next rebuild and redeploy, even when the icon name is valid; see [Icons Set in Nuxt Studio CMS](./icon-usage.md#icons-set-in-nuxt-studio-cms).
 
 ### License Compliance
 

--- a/docs/template-usage.md
+++ b/docs/template-usage.md
@@ -191,6 +191,8 @@ For easily managing the template, we provide a CLI tool to streamline the proces
 
 > [!NOTE]
 > Changes made in the CMS are only visible to you until saved in the sidebar. Save your updates to make them public. After saving, it takes about 2–10 minutes for changes to go live while the website rebuilds. Avoid saving too frequently; each save triggers a new build, and you may be charged per build depending on your hosting provider.
+>
+> Icon names are collected at build time from project files in `app/`, `shared/`, and `content/` (for example `.json`, `.md`, `.yml`). If you change an icon name in Nuxt Studio, the new icon appears after the next build. Literal icon names are required for detection.
 
 ### License Compliance
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -108,7 +108,6 @@ export default defineNuxtConfig({
       collections: [
         'lucide',
         'mdi',
-        'noto',
         'simple-icons',
       ],
     },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -106,6 +106,7 @@ export default defineNuxtConfig({
     fallbackToApi: false,
     serverBundle: false,
     clientBundle: {
+      sizeLimitKb: 64,
       scan: {
         globInclude: [
           'app/**/*.{vue,ts,js,mjs,md,mdc,mdx,yml,yaml,json}',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,16 +100,19 @@ export default defineNuxtConfig({
   },
 
   icon: {
-    // Use server provider with local bundles so Nuxt Studio users can pick icons freely
-    // from installed collections, without external Iconify API requests.
-    provider: 'server',
+    // Client-bundle-only icons: scan source and content files at build time,
+    // then ship only discovered icons (no server icon bundle, no external API fallback).
+    provider: 'none',
     fallbackToApi: false,
-    serverBundle: {
-      collections: [
-        'lucide',
-        'mdi',
-        'simple-icons',
-      ],
+    serverBundle: false,
+    clientBundle: {
+      scan: {
+        globInclude: [
+          'app/**/*.{vue,ts,js,mjs,md,mdc,mdx,yml,yaml,json}',
+          'shared/**/*.{ts,js,mjs,md,mdc,mdx,yml,yaml,json}',
+          'content/**/*.{md,mdc,mdx,yml,yaml,json}',
+        ],
+      },
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@antfu/eslint-config": "~7.2.0",
     "@iconify-json/lucide": "~1.2.102",
     "@iconify-json/mdi": "~1.2.3",
-    "@iconify-json/noto": "~1.2.7",
     "@iconify-json/simple-icons": "~1.2.77",
     "@nuxt/content": "~3.11.2",
     "@nuxt/eslint": "~1.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@iconify-json/mdi':
         specifier: ~1.2.3
         version: 1.2.3
-      '@iconify-json/noto':
-        specifier: ~1.2.7
-        version: 1.2.7
       '@iconify-json/simple-icons':
         specifier: ~1.2.77
         version: 1.2.77
@@ -1073,9 +1070,6 @@ packages:
 
   '@iconify-json/mdi@1.2.3':
     resolution: {integrity: sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==}
-
-  '@iconify-json/noto@1.2.7':
-    resolution: {integrity: sha512-2pNHliXnMLpnepNTZwR9hPBSl6GmhIfXPnudFCHY5v9pJhmA7LoVb/pFY0qLDY/k+3ikET8RXRf7XFxc/pHObA==}
 
   '@iconify-json/simple-icons@1.2.77':
     resolution: {integrity: sha512-oaENvo6C3BkAEWMlcQA3XemxU9v2SFOTlApSUCODAkIu1haeLCjzrmH3HgmGqjRnJjM+LevO8sA+MgdMHBFBDA==}
@@ -10623,10 +10617,6 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify-json/mdi@1.2.3':
-    dependencies:
-      '@iconify/types': 2.0.0
-
-  '@iconify-json/noto@1.2.7':
     dependencies:
       '@iconify/types': 2.0.0
 


### PR DESCRIPTION
This PR updates icon handling to a client-scan bundle flow and removes an unused emoji icon collection (noto icon pack).

**Specifically, it addresses and includes the following:**

- Changed Nuxt Icon settings.
- Removed `noto` emoji icon pack.
- Added a Nuxt Studio note in `docs/template-usage.md` that new literal icon names appear after the next build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that icon names are detected at build time by scanning project files and added a cross-reference to the new guidance.
  * Added a visible warning in the CMS/editor that newly set icon names may not appear in live preview until the next rebuild and redeploy.

* **Chores**
  * Removed the Noto Emojis icon collection and its dependency.
  * Switched icon delivery to build-time scanning (client-side bundle) instead of server bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->