### PR TITLE
feat: add configurable color mode policy in custom config

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -12,7 +12,7 @@ const appConfig = useAppConfig()
 const footerConfig = appConfig.footer
 const columnsConfig = footerConfig?.footerColumns
 const bottomIcons = footerConfig?.bottomIcons
-const canSwitchColorMode = appConfig.general.colorMode === 'both'
+const canSwitchColorMode = isColorSwitchable(appConfig.general.colorMode)
 
 // year span calculation
 const yearCurrent = new Date().getFullYear()

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -12,6 +12,7 @@ const appConfig = useAppConfig()
 const footerConfig = appConfig.footer
 const columnsConfig = footerConfig?.footerColumns
 const bottomIcons = footerConfig?.bottomIcons
+const canSwitchColorMode = appConfig.general.colorMode === 'both'
 
 // year span calculation
 const yearCurrent = new Date().getFullYear()
@@ -202,7 +203,7 @@ function navigateToAdmin() {
         variant="ghost"
       />
 
-      <UColorModeButton />
+      <UColorModeButton v-if="canSwitchColorMode" />
     </template>
   </UFooter>
 </template>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -2,7 +2,7 @@
 const route = useRoute()
 const appConfig = useAppConfig()
 
-const canSwitchColorMode = computed(() => appConfig.general.colorMode === 'both')
+const canSwitchColorMode = computed(() => isColorSwitchable(appConfig.general.colorMode))
 
 const items = computed(() => [
   {

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 const route = useRoute()
+const appConfig = useAppConfig()
+
+const canSwitchColorMode = computed(() => appConfig.general.colorMode === 'both')
 
 const items = computed(() => [
   {
@@ -44,7 +47,7 @@ const items = computed(() => [
     </template>
 
     <template #right>
-      <UColorModeButton />
+      <UColorModeButton v-if="canSwitchColorMode" />
 
       <UButton
         aria-label="Buy tickets"

--- a/app/schemas/customConfig.ts
+++ b/app/schemas/customConfig.ts
@@ -30,6 +30,10 @@ export const customConfigSchema = z.object({
       description: 'The time zone where the conference takes place, e.g. `Europe/Berlin`. '
         + 'This is used to display the schedule in the correct local time.',
     }),
+    colorMode: property(z.enum(['both', 'light-only', 'dark-only']).default('both')).editor({
+      // @ts-expect-error `description` is custom and patched in `nuxt-studio`
+      description: 'Color mode behavior for the website: allow switching (`both`) or lock it to one mode.',
+    }),
     siteUrl: property(z.url().min(1)).editor({
       // @ts-expect-error `description` is custom and patched in `nuxt-studio`
       description: 'The public URL of the website (e.g. `https://my-conference.com`).',

--- a/app/schemas/customConfig.ts
+++ b/app/schemas/customConfig.ts
@@ -30,13 +30,13 @@ export const customConfigSchema = z.object({
       description: 'The time zone where the conference takes place, e.g. `Europe/Berlin`. '
         + 'This is used to display the schedule in the correct local time.',
     }),
-    colorMode: property(z.enum(['both', 'light-only', 'dark-only']).default('both')).editor({
-      // @ts-expect-error `description` is custom and patched in `nuxt-studio`
-      description: 'Color mode behavior for the website: allow switching (`both`) or lock it to one mode.',
-    }),
     siteUrl: property(z.url().min(1)).editor({
       // @ts-expect-error `description` is custom and patched in `nuxt-studio`
       description: 'The public URL of the website (e.g. `https://my-conference.com`).',
+    }),
+    colorMode: property(z.enum(['both', 'light-only', 'dark-only']).default('both')).editor({
+      // @ts-expect-error `description` is custom and patched in `nuxt-studio`
+      description: 'Color mode behavior for the website: allow switching (`both`) or lock it to one mode.',
     }),
     logo: property(z.object({
       light: property(z.string().min(1)).editor({

--- a/app/schemas/customConfigPlain.ts
+++ b/app/schemas/customConfigPlain.ts
@@ -30,6 +30,7 @@ export const customConfigSchema = z.object({
     conferenceName: z.string().min(1),
     conferenceFoundingYear: z.number().default(new Date().getFullYear()),
     timeZone: z.string().default('UTC'),
+    colorMode: z.enum(['both', 'light-only', 'dark-only']).default('both'),
     siteUrl: z.url().min(1),
     logo: z.object({
       light: z.string().min(1),

--- a/app/schemas/customConfigPlain.ts
+++ b/app/schemas/customConfigPlain.ts
@@ -30,8 +30,8 @@ export const customConfigSchema = z.object({
     conferenceName: z.string().min(1),
     conferenceFoundingYear: z.number().default(new Date().getFullYear()),
     timeZone: z.string().default('UTC'),
-    colorMode: z.enum(['both', 'light-only', 'dark-only']).default('both'),
     siteUrl: z.url().min(1),
+    colorMode: z.enum(['both', 'light-only', 'dark-only']).default('both'),
     logo: z.object({
       light: z.string().min(1),
       dark: z.string().min(1),

--- a/app/utils/color-mode.ts
+++ b/app/utils/color-mode.ts
@@ -1,0 +1,39 @@
+export type ColorModePolicy = 'both' | 'light-only' | 'dark-only'
+
+interface ColorModeSetting {
+  preference: 'system' | 'light' | 'dark'
+  fallback: 'light' | 'dark'
+}
+
+const defaultColorModePolicy: ColorModePolicy = 'both'
+
+const colorModeSettings: Record<ColorModePolicy, ColorModeSetting> = {
+  'both': {
+    preference: 'system',
+    fallback: 'dark',
+  },
+  'light-only': {
+    preference: 'light',
+    fallback: 'light',
+  },
+  'dark-only': {
+    preference: 'dark',
+    fallback: 'dark',
+  },
+}
+
+export function resolveColorModePolicy(policy: unknown): ColorModePolicy {
+  if (policy === 'both' || policy === 'light-only' || policy === 'dark-only') {
+    return policy
+  }
+
+  return defaultColorModePolicy
+}
+
+export function getColorModeSetting(policy: unknown): ColorModeSetting {
+  return colorModeSettings[resolveColorModePolicy(policy)]
+}
+
+export function isColorSwitchable(policy: unknown): boolean {
+  return resolveColorModePolicy(policy) === 'both'
+}

--- a/content/0.custom-config.json
+++ b/content/0.custom-config.json
@@ -30,6 +30,7 @@
     }
   },
   "general": {
+    "colorMode": "both",
     "conferenceFoundingYear": 2025,
     "conferenceName": "ConferenceNamePlaceholder",
     "favicon": {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -104,6 +104,8 @@ export default defineNuxtConfig({
   colorMode: { // for `@nuxt/color-mode` (included in `@nuxt/ui`)
     preference: selectedColorModeSetting.preference,
     fallback: selectedColorModeSetting.fallback,
+    
+    // Keep mode-specific storage keys so old persisted preferences do not override a new forced mode policy.
     storageKey: `quick-conf-color-mode-${customConfig.general.colorMode}`,
   },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,7 @@
 
 import type { CustomConfig } from './app/schemas/customConfigPlain'
 import { customConfigSchema } from './app/schemas/customConfigPlain'
+import { getColorModeSetting, resolveColorModePolicy } from './app/utils/color-mode'
 import { formatCustomConfigValidationErrors } from './app/utils/custom-config-validation'
 import _customConfig from './content/0.custom-config.json'
 
@@ -15,22 +16,10 @@ if (!parseResult.success) {
 
 const customConfig = (parseResult.success ? parseResult.data : _customConfig) as CustomConfig
 
-const colorModeSettings = {
-  'both': {
-    preference: 'system',
-    fallback: 'dark',
-  },
-  'light-only': {
-    preference: 'light',
-    fallback: 'light',
-  },
-  'dark-only': {
-    preference: 'dark',
-    fallback: 'dark',
-  },
-} as const
+const configuredColorMode = customConfig?.general?.colorMode as string | undefined
+const resolvedColorModePolicy = resolveColorModePolicy(configuredColorMode)
 
-const selectedColorModeSetting = colorModeSettings[customConfig.general.colorMode]
+const selectedColorModeSetting = getColorModeSetting(resolvedColorModePolicy)
 
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
@@ -106,7 +95,7 @@ export default defineNuxtConfig({
     fallback: selectedColorModeSetting.fallback,
 
     // Keep mode-specific storage keys so old persisted preferences do not override a new forced mode policy.
-    storageKey: `quick-conf-color-mode-${customConfig.general.colorMode}`,
+    storageKey: `quick-conf-color-mode-${resolvedColorModePolicy}`,
   },
 
   ui: { // for `@nuxt/ui`

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -104,7 +104,7 @@ export default defineNuxtConfig({
   colorMode: { // for `@nuxt/color-mode` (included in `@nuxt/ui`)
     preference: selectedColorModeSetting.preference,
     fallback: selectedColorModeSetting.fallback,
-    
+
     // Keep mode-specific storage keys so old persisted preferences do not override a new forced mode policy.
     storageKey: `quick-conf-color-mode-${customConfig.general.colorMode}`,
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,6 +15,23 @@ if (!parseResult.success) {
 
 const customConfig = (parseResult.success ? parseResult.data : _customConfig) as CustomConfig
 
+const colorModeSettings = {
+  'both': {
+    preference: 'system',
+    fallback: 'dark',
+  },
+  'light-only': {
+    preference: 'light',
+    fallback: 'light',
+  },
+  'dark-only': {
+    preference: 'dark',
+    fallback: 'dark',
+  },
+} as const
+
+const selectedColorModeSetting = colorModeSettings[customConfig.general.colorMode]
+
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
 
@@ -82,6 +99,12 @@ export default defineNuxtConfig({
         strict: true,
       },
     },
+  },
+
+  colorMode: { // for `@nuxt/color-mode` (included in `@nuxt/ui`)
+    preference: selectedColorModeSetting.preference,
+    fallback: selectedColorModeSetting.fallback,
+    storageKey: `quick-conf-color-mode-${customConfig.general.colorMode}`,
   },
 
   ui: { // for `@nuxt/ui`


### PR DESCRIPTION
This PR adds configurable color mode behavior via custom config and applies the mode policy across runtime configuration and UI controls.

**Specifically, it addresses and includes the following:**

- Adds `general.colorMode` enum (`both`, `light-only`, `dark-only`) in both custom config schemas.
- Wires `general.colorMode` into Nuxt `colorMode` options for `preference`, `fallback`, and mode-specific `storageKey`.
- Hides `UColorModeButton` in header and footer when mode switching is not allowed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable color mode: "both", "light-only", or "dark-only" (default: both).
  * Theme toggle in header and footer appears only when switching is allowed by the setting.
  * Theme preference selection and persistence now follow the chosen color-mode policy for consistent behavior across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->