### PR TITLE
feat: add custom config setting for Nuxt Content syntax highlighting

### DIFF
--- a/app/schemas/customConfig.ts
+++ b/app/schemas/customConfig.ts
@@ -244,6 +244,16 @@ export const customConfigSchema = z.object({
     description: 'NuxtUI Customization.',
   }),
 
+  nuxtContent: property(z.object({
+    syntaxHighlighting: property(z.boolean().default(false)).editor({
+      // @ts-expect-error `description` is custom and patched in `nuxt-studio`
+      description: 'Enable syntax highlighting for Markdown code blocks. Keep this disabled to reduce bundle size.',
+    }),
+  })).editor({
+    // @ts-expect-error `description` is custom and patched in `nuxt-studio`
+    description: 'Nuxt Content customization.',
+  }),
+
   ogImage: property(z.object({
     bgLight: property(
       z.string().regex(/^#(?:[0-9a-f]{3}){1,2}$/i, 'Use a valid hex color').default('#ffffff'),

--- a/app/schemas/customConfig.ts
+++ b/app/schemas/customConfig.ts
@@ -239,7 +239,7 @@ export const customConfigSchema = z.object({
       // @ts-expect-error `description` is custom and patched in `nuxt-studio`
       description: 'Icons used across the UI.',
     }),
-  })).editor({
+  }).optional()).editor({
     // @ts-expect-error `description` is custom and patched in `nuxt-studio`
     description: 'NuxtUI Customization.',
   }),
@@ -249,7 +249,7 @@ export const customConfigSchema = z.object({
       // @ts-expect-error `description` is custom and patched in `nuxt-studio`
       description: 'Enable syntax highlighting for Markdown code blocks. Keep this disabled to reduce bundle size.',
     }),
-  })).editor({
+  }).optional()).editor({
     // @ts-expect-error `description` is custom and patched in `nuxt-studio`
     description: 'Nuxt Content customization.',
   }),

--- a/app/schemas/customConfigPlain.ts
+++ b/app/schemas/customConfigPlain.ts
@@ -109,11 +109,11 @@ export const customConfigSchema = z.object({
       chevron: 'lucide:chevron-down',
       hash: 'lucide:hash',
     }),
-  }),
+  }).optional(),
 
   nuxtContent: z.object({
     syntaxHighlighting: z.boolean().default(false),
-  }),
+  }).optional(),
 
   ogImage: z.object({
     bgLight: z.string().regex(/^#(?:[0-9a-f]{3}){1,2}$/i, 'Use a valid hex color').default('#ffffff'),

--- a/app/schemas/customConfigPlain.ts
+++ b/app/schemas/customConfigPlain.ts
@@ -111,6 +111,10 @@ export const customConfigSchema = z.object({
     }),
   }),
 
+  nuxtContent: z.object({
+    syntaxHighlighting: z.boolean().default(false),
+  }),
+
   ogImage: z.object({
     bgLight: z.string().regex(/^#(?:[0-9a-f]{3}){1,2}$/i, 'Use a valid hex color').default('#ffffff'),
     bgDark: z.string().regex(/^#(?:[0-9a-f]{3}){1,2}$/i, 'Use a valid hex color').default('#0f172a'),

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -187,6 +187,12 @@ export default defineNuxtConfig({
   },
 
   content: { // for `@nuxt/content`
+    build: {
+      markdown: {
+        // Syntax highlighting in runtime content pages with Shiki produces large wasm/highlighter chunks in build.
+        highlight: customConfig?.nuxtContent?.syntaxHighlighting ? {} : false,
+      },
+    },
     experimental: {
       // Connector selection order in @nuxt/content v3.11.2 (findBestSqliteAdapter):
       // 1) bun runtime -> bun-sqlite


### PR DESCRIPTION
This PR adds a user-facing toggle setting for Nuxt Content syntax highlighting and wires it into Nuxt configuration with a default off state.

**Specifically, it addresses and includes the following:**

- Adds `nuxtContent.syntaxHighlighting` to both custom config schemas with a `false` default.
- Exposes the setting in the Studio schema with editor metadata so users can change it from config content.
- Wires `content.build.markdown.highlight` to `customConfig?.nuxtContent?.syntaxHighlighting ? {} : false` in Nuxt config.
- Keeps syntax highlighting disabled by default to avoid loading larger Shiki-related bundles unless explicitly enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable syntax highlighting for Markdown content; users can enable or disable it via app configuration.

* **Chores**
  * The UI configuration block is now optional, allowing setups without that configuration while preserving its editor metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->