### PR TITLE
docs: expand README key features and demo context

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ This is a **completely free** template for quickly setting up a new Conference o
 ## 🚀 Key Features
 
 - **🎨 Customizable**: Fully theming via [Nuxt UI](https://ui.nuxt.com) and configuration files - your colors, your style!
-- **📝 CMS Integration**: [Nuxt Studio](https://nuxt.studio) ready for visual editing - directly in the browser!
+- **📝 Git-Based CMS Editing**: [Nuxt Studio](https://nuxt.studio) ready for visual editing, live preview, and content updates directly in the browser.
+- **🖥️ Venue-Ready Display Mode**: One `/display` route with three modes (`timetable`, `all-details`, `stage-details`) for hallways, foyers, and stage-focused room screens.
+- **🔗 Shareable Display Setup**: URL query parameters persist the full display configuration, so copied links reopen the same setup on any screen.
+- **⏱️ Live Display Controls**: Stage/day selection, sponsor modes (`off`, `all`, `rotate`), QR link block to `/schedule`, and refresh presets (`60`, `120`, `300` seconds).
+- **📅 Timezone-Aware Schedule**: Talks are normalized from UTC to the configured event timezone for accurate schedule and display output.
+- **🧩 Modular Landing Blocks**: Build pages from reusable content blocks managed in collections.
+- **✅ Schema-Validated Content**: [Nuxt Content](https://content.nuxt.com) collections are validated with [Zod](https://zod.dev) schemas for talks, speakers, stages, sponsors, tickets, FAQ, and pages.
 - **⚡ Modern Stack**: [Nuxt 4](https://nuxt.com), [Vue 3](https://vuejs.org), [Tailwind CSS 4](https://tailwindcss.com), [TypeScript](https://www.typescriptlang.org).
-- **🖥️ Unified Display Mode**: One `/display` page for stage-focused signage and full timetable mode with shareable URL settings.
 - **🔍 SEO Ready**: Pre-configured via [Nuxt SEO](https://nuxtseo.com/) with:
   - ✅ Automatic **Sitemap** (`/sitemap.xml`)
   - ✅ Dynamic **OG Images** (Social Cards) for speakers, talks & pages

--- a/README.md
+++ b/README.md
@@ -7,20 +7,18 @@ This is a **completely free** template for quickly setting up a new Conference o
 
 ## 🚀 Key Features
 
+- **⚡ Modern Stack**: [Nuxt 4](https://nuxt.com), [Vue 3](https://vuejs.org), [Tailwind CSS 4](https://tailwindcss.com), [TypeScript](https://www.typescriptlang.org).
 - **🎨 Customizable**: Fully theming via [Nuxt UI](https://ui.nuxt.com) and configuration files - your colors, your style!
 - **📝 Git-Based CMS Editing**: [Nuxt Studio](https://nuxt.studio) ready for visual editing, live preview, and content updates directly in the browser.
-- **🖥️ Venue-Ready Display Mode**: One `/display` route with three modes (`timetable`, `all-details`, `stage-details`) for hallways, foyers, and stage-focused room screens.
-- **🔗 Shareable Display Setup**: URL query parameters persist the full display configuration, so copied links reopen the same setup on any screen.
-- **⏱️ Live Display Controls**: Stage/day selection, sponsor modes (`off`, `all`, `rotate`), QR link block to `/schedule`, and refresh presets (`60`, `120`, `300` seconds).
-- **📅 Timezone-Aware Schedule**: Talks are normalized from UTC to the configured event timezone for accurate schedule and display output.
-- **🧩 Modular Landing Blocks**: Build pages from reusable content blocks managed in collections.
-- **✅ Schema-Validated Content**: [Nuxt Content](https://content.nuxt.com) collections are validated with [Zod](https://zod.dev) schemas for talks, speakers, stages, sponsors, tickets, FAQ, and pages.
-- **⚡ Modern Stack**: [Nuxt 4](https://nuxt.com), [Vue 3](https://vuejs.org), [Tailwind CSS 4](https://tailwindcss.com), [TypeScript](https://www.typescriptlang.org).
 - **🔍 SEO Ready**: Pre-configured via [Nuxt SEO](https://nuxtseo.com/) with:
   - ✅ Automatic **Sitemap** (`/sitemap.xml`)
   - ✅ Dynamic **OG Images** (Social Cards) for speakers, talks & pages
   - ✅ Smart **Robots.txt** (Blocks AI Bots, permits legitimate crawlers)
   - ✅ JSON-LD Structured Data
+- **🖥️ Venue-Ready Display Mode**: One `/display` route with three modes (`timetable`, `all-details`, `stage-details`) for hallways, foyers, and stage-focused room screens.
+- **📅 Timezone-Aware Schedule**: Talks are normalized from UTC to the configured event timezone for accurate schedule and display output.
+- **🧩 Modular Landing Blocks**: Build pages from reusable content blocks managed in collections.
+- **✅ Schema-Validated Content**: [Nuxt Content](https://content.nuxt.com) collections are validated with [Zod](https://zod.dev) schemas for talks, speakers, stages, sponsors, tickets, FAQ, and pages.
 
 ## 🌐 Live Demo
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a **completely free** template for quickly setting up a new Conference o
 ## 🚀 Key Features
 
 - **⚡ Modern Stack**: [Nuxt 4](https://nuxt.com), [Vue 3](https://vuejs.org), [Tailwind CSS 4](https://tailwindcss.com), [TypeScript](https://www.typescriptlang.org).
-- **🎨 Customizable**: Fully theming via [Nuxt UI](https://ui.nuxt.com) and configuration files - your colors, your style!
+- **🎨 Customizable**: Fully themeable via [Nuxt UI](https://ui.nuxt.com) and configuration files - your colors, your style!
 - **📝 Git-Based CMS Editing**: [Nuxt Studio](https://nuxt.studio) ready for visual editing, live preview, and content updates directly in the browser.
 - **🔍 SEO Ready**: Pre-configured via [Nuxt SEO](https://nuxtseo.com/) with:
   - ✅ Automatic **Sitemap** (`/sitemap.xml`)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can find a deployed version of this template to test and view here:
 
 🔗 Demo: [https://quick-conf.com/](https://quick-conf.com/)
 
+> The deployed demo runs from the repository [toddeTV/quick-conf-demo](https://github.com/toddeTV/quick-conf-demo). That repository is a practical usage example of this template and shows one real project setup based on `quick-conf`.
+
 🎥 Video: [Showcase Video](https://youtu.be/uh-Rys6nTKI)
 
 📸 Screenshots


### PR DESCRIPTION
This PR updates README messaging to describe the template feature set with clearer, production-focused wording. It adds a live demo repository note and refines Key Features order.

**Specifically, it addresses and includes the following:**

- Expanded Key Features with concrete display mode capabilities and operational controls.
- Added explicit attribution of the deployed demo to `toddeTV/quick-conf-demo` as the reference implementation.
- Reordered and condensed feature bullets to reduce overlap and improve scanability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Detailed Git-based CMS editing with live preview and in-browser content updates
  * Updated Display Mode docs describing a venue-ready /display route with three modes: timetable, all-details, stage-details
  * Added timezone-aware schedule normalization, modular landing blocks from reusable collections, and schema-validated content notes
  * Referenced live demo repository as an example implementation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->