### PR TITLE
fix: add trust policy grace period for fresh installs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 shellEmulator: true
 trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 10080
 patchedDependencies:
   nuxt-studio@1.6.0: patches/nuxt-studio.patch
 allowBuilds:


### PR DESCRIPTION
This PR adds a trust-policy grace window for package age in the workspace pnpm configuration. It fixes fresh-template installation paths where the lockfile is removed and dependency resolution can fail with trust downgrade checks.

**Specifically, it addresses and includes the following:**

- Added `trustPolicyIgnoreAfter: 10080` to `pnpm-workspace.yaml` to permit older package versions that predate current trust metadata requirements.
- Preserved `trustPolicy: no-downgrade`, so strict trust checks remain active for newer packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration to extend trust policy behavior with a new timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->